### PR TITLE
use numericLiteral over numberLiteral

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function astify(literal) {
   case 'boolean':
     return t.booleanLiteral(literal);
   case 'undefined':
-    return t.unaryExpression('void', t.numberLiteral(0), true);
+    return t.unaryExpression('void', t.numericLiteral(0), true);
   default:
     if (Array.isArray(literal)) {
       return t.arrayExpression(literal.map(astify));


### PR DESCRIPTION
This solves a deprecation from babel.

```
Trace: The node type NumberLiteral has been renamed to NumericLiteral
    at Object.<anonymous> (/docs/node_modules/babel-types/lib/index.js:481:15)
    at astify (/docs/node_modules/babel-literal-to-ast/src/index.js:24:40)
    at Object.keys.map.key (/docs/lib/myMarkdownBabelPlugin.js:24:74)
    at Array.map (native)
    at mapProps (/docs/lib/myMarkdownBabelPlugin.js:19:28)
    at NR (/docs/lib/myMarkdownBabelPlugin.js:60:9)
    at code (/docs/lib/myMarkdownBabelPlugin.js:108:14)
    at children.reduce.map (/docs/lib/myMarkdownBabelPlugin.js:87:30)
    at Array.map (native)
    at mapChildren (/docs/lib/myMarkdownBabelPlugin.js:87:8)
```